### PR TITLE
Fixed wording and added text to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,13 +38,13 @@ _|_  '  _||_  \\__//  _|_  \|   \\__//  _|_  \|   \\__//  _||_ \\_ _||_
       <div class="box">
         <a href="https://github.com/madmalik/mononoki/tree/master">View on github</a>
       </div>
-      <div class="box">    
+      <div class="box">
         <a href="https://github.com/madmalik/mononoki/blob/master/export/mononoki.zip">Download</a>
       </div>
     </div>
     <div class="container">
       <div class="box">
-        <div class="dropcap">___      ___ 
+        <div class="dropcap">___      ___
  |\\    /||
  | \\  / ||
  |  \\/  ||
@@ -52,7 +52,7 @@ _|_  '  _||_</div><br>ononoki is a typeface by Matthias Tellen, created to enhan
 
       </div>
       <div class="box code">
-<span class="comment"># how to ace an interview</span>     
+<span class="comment"># how to ace an interview</span>
 <span class="keyword">for</span> i <span class="keyword">in</span> xrange(1, 101)<span class="op">:</span>
     <span class="keyword">if</span> i <span class="op">%</span> 15 <span class="op">==</span> 0<span class="op">:</span>
         <span class="keyword">print</span> <span class="string">"mononoki"</span>
@@ -76,13 +76,13 @@ _|_  '  _||_</div><br>ononoki is a typeface by Matthias Tellen, created to enhan
       </div>
 
       <div class="box">
-        <div class="dropcap">________  
-|/ || \| 
-   || 
+        <div class="dropcap">________
+|/ || \|
+   ||
    ||
   _||_</div><br>
-his is an universal requirement for source code typography. <br>
-It's not just an historic artifact from the olden days of terminals, but an useful convention to allow 
+his is a universal requirement for source code typography. <br>
+It's not just a historic artifact from the olden days of terminals, but a useful convention to allow
 two dimensional structuring and highlighting differences on the character level.<br>
       </div>
     </div>
@@ -92,21 +92,21 @@ two dimensional structuring and highlighting differences on the character level.
       <div class="background">&g<span class="italic">g</span></div>
 
       <div class="box resolution-title">
-        <span class="italic">works well on</span> 
-        <div class="high">high</div> 
+        <span class="italic">works well on</span>
+        <div class="high">high</div>
         <span class="italic">and</span>
         <div><img src="low.png" alt="low" height="45"></div>
         <span class="italic">resolution displays</span>
         </span>
-      
+
       </div>
       <div class="box">
         <div class="dropcap">____
- || \\ 
- ||_// 
+ || \\
+ ||_//
  ||\\
 _||_\\_ </div><br>
-ight now we are in the transition Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+ight now we are in the transition to high resolution displays, bringing font rendering quality on screen to the realms of print quality. But we're not there yet, and especially on cheap laptops and typical office displays this transition will not be accomplished in the foreseeable future. So the glyphs must survive being squashed into a grid of a few pixels extremely well, but I still wanted to design them with attention to detail although it is only visible in print or on retina displays.
       </div>
 
      </div>
@@ -122,12 +122,12 @@ ight now we are in the transition Lorem ipsum dolor sit amet, consetetur sadipsc
       </div>
 
       <div class="box">
-        <div class="dropcap">_______ 
- ||  \| 
- ||__ 
- || 
+        <div class="dropcap">_______
+ ||  \|
+ ||__
+ ||
 _||__/|</div><br>
-very character is clearly distinguishable from similar Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+very character is clearly distinguishable from similar looking characters. While this seems obvious, it comes with costs, like inferior long-text readability and a less consistent appearance. I wanted to reach this goal with minimal tradeoffs.
       </div>
     </div>
 <div class="wingdings">¶</div>
@@ -136,7 +136,7 @@ very character is clearly distinguishable from similar Lorem ipsum dolor sit ame
 
 
     <div class="showcase">
-&#65;<wbr>&#193;<wbr>&#258;<wbr>&#194;<wbr>&#196;<wbr>&#192;<wbr>&#256;<wbr>&#260;<wbr>&#197;<wbr>&#195;<wbr>&#198;<wbr>&#66;<wbr>&#67;<wbr>&#262;<wbr>&#268;<wbr>&#199;<wbr>&#68;<wbr>&#208;<wbr>&#270;<wbr>&#272;<wbr>&#69;<wbr>&#201;<wbr>&#282;<wbr>&#202;<wbr>&#203;<wbr>&#278;<wbr>&#200;<wbr>&#274;<wbr>&#280;<wbr>&#70;<wbr>&#71;<wbr>&#72;<wbr>&#73;<wbr>&#306;<wbr>&#205;<wbr>&#206;<wbr>&#207;<wbr>&#204;<wbr>&#298;<wbr>&#302;<wbr>&#74;<wbr>&#75;<wbr>&#76;<wbr>&#313;<wbr>&#317;<wbr>&#319;<wbr>&#77;<wbr>&#78;<wbr>&#323;<wbr>&#327;<wbr>&#209;<wbr>&#79;<wbr>&#211;<wbr>&#212;<wbr>&#214;<wbr>&#210;<wbr>&#336;<wbr>&#332;<wbr>&#216;<wbr>&#213;<wbr>&#338;<wbr>&#80;<wbr>&#222;<wbr>&#81;<wbr>&#82;<wbr>&#340;<wbr>&#344;<wbr>&#83;<wbr>&#346;<wbr>&#352;<wbr>&#350;<wbr>&#84;<wbr>&#358;<wbr>&#356;<wbr>&#354;<wbr>&#85;<wbr>&#218;<wbr>&#219;<wbr>&#220;<wbr>&#217;<wbr>&#368;<wbr>&#362;<wbr>&#370;<wbr>&#366;<wbr>&#86;<wbr>&#87;<wbr>&#7810;<wbr>&#372;<wbr>&#7812;<wbr>&#7808;<wbr>&#88;<wbr>&#89;<wbr>&#221;<wbr>&#374;<wbr>&#376;<wbr>&#7922;<wbr>&#90;<wbr>&#377;<wbr>&#381;<wbr>&#379;<wbr>&#97;<wbr>&#225;<wbr>&#259;<wbr>&#226;<wbr>&#228;<wbr>&#224;<wbr>&#257;<wbr>&#261;<wbr>&#229;<wbr>&#227;<wbr>&#230;<wbr>&#98;<wbr>&#99;<wbr>&#263;<wbr>&#269;<wbr>&#231;<wbr>&#100;<wbr>&#240;<wbr>&#271;<wbr>&#273;<wbr>&#101;<wbr>&#233;<wbr>&#283;<wbr>&#234;<wbr>&#235;<wbr>&#279;<wbr>&#232;<wbr>&#275;<wbr>&#281;<wbr>&#102;<wbr>&#103;<wbr>&#104;<wbr>&#105;<wbr>&#305;<wbr>&#237;<wbr>&#238;<wbr>&#239;<wbr>&#236;<wbr>&#307;<wbr>&#299;<wbr>&#303;<wbr>&#106;<wbr>&#567;<wbr>&#107;<wbr>&#108;<wbr>&#314;<wbr>&#318;<wbr>&#320;<wbr>&#109;<wbr>&#110;<wbr>&#324;<wbr>&#328;<wbr>&#241;<wbr>&#111;<wbr>&#243;<wbr>&#244;<wbr>&#246;<wbr>&#242;<wbr>&#337;<wbr>&#333;<wbr>&#248;<wbr>&#245;<wbr>&#339;<wbr>&#112;<wbr>&#254;<wbr>&#113;<wbr>&#114;<wbr>&#341;<wbr>&#345;<wbr>&#115;<wbr>&#347;<wbr>&#353;<wbr>&#351;<wbr>&#223;<wbr>&#116;<wbr>&#359;<wbr>&#357;<wbr>&#355;<wbr>&#117;<wbr>&#250;<wbr>&#251;<wbr>&#252;<wbr>&#249;<wbr>&#369;<wbr>&#363;<wbr>&#371;<wbr>&#367;<wbr>&#118;<wbr>&#119;<wbr>&#7811;<wbr>&#373;<wbr>&#7813;<wbr>&#7809;<wbr>&#120;<wbr>&#121;<wbr>&#253;<wbr>&#375;<wbr>&#255;<wbr>&#7923;<wbr>&#122;<wbr>&#378;<wbr>&#382;<wbr>&#380;<wbr>&#170;<wbr>&#186;<wbr>&#913;<wbr>&#914;<wbr>&#915;<wbr>&#916;<wbr>&#917;<wbr>&#918;<wbr>&#919;<wbr>&#920;<wbr>&#921;<wbr>&#922;<wbr>&#923;<wbr>&#924;<wbr>&#925;<wbr>&#926;<wbr>&#927;<wbr>&#928;<wbr>&#929;<wbr>&#931;<wbr>&#932;<wbr>&#933;<wbr>&#934;<wbr>&#935;<wbr>&#936;<wbr>&#937;<wbr>&#945;<wbr>&#946;<wbr>&#947;<wbr>&#948;<wbr>&#949;<wbr>&#950;<wbr>&#951;<wbr>&#952;<wbr>&#953;<wbr>&#954;<wbr>&#955;<wbr>&#956;<wbr>&#957;<wbr>&#958;<wbr>&#959;<wbr>&#960;<wbr>&#961;<wbr>&#963;<wbr>&#964;<wbr>&#965;<wbr>&#966;<wbr>&#967;<wbr>&#968;<wbr>&#969;<wbr>&#48;<wbr>&#49;<wbr>&#50;<wbr>&#51;<wbr>&#52;<wbr>&#53;<wbr>&#54;<wbr>&#55;<wbr>&#56;<wbr>&#57;<wbr>&#8543;<wbr>&#189;<wbr>&#8585;<wbr>&#8531;<wbr>&#8532;<wbr>&#188;<wbr>&#190;<wbr>&#8533;<wbr>&#8534;<wbr>&#8535;<wbr>&#8536;<wbr>&#8537;<wbr>&#8538;<wbr>&#8528;<wbr>&#8539;<wbr>&#8540;<wbr>&#8541;<wbr>&#8542;<wbr>&#8529;<wbr>&#8530;<wbr>&#42;<wbr>&#92;<wbr>&#183;<wbr>&#8226;<wbr>&#58;<wbr>&#44;<wbr>&#8230;<wbr>&#33;<wbr>&#8252;<wbr>&#161;<wbr>&#35;<wbr>&#8228;<wbr>&#46;<wbr>&#63;<wbr>&#191;<wbr>&#34;<wbr>&#39;<wbr>&#59;<wbr>&#47;<wbr>&#8229;<wbr>&#95;<wbr>&#123;<wbr>&#125;<wbr>&#91;<wbr>&#93;<wbr>&#40;<wbr>&#41;<wbr>&#45;<wbr>&#171;<wbr>&#187;<wbr>&#8249;<wbr>&#8250;<wbr>&#8222;<wbr>&#8220;<wbr>&#8221;<wbr>&#8216;<wbr>&#8219;<wbr>&#8217;<wbr>&#8218;<wbr>&#162;<wbr>&#164;<wbr>&#36;<wbr>&#8364;<wbr>&#402;<wbr>&#163;<wbr>&#165;<wbr>&#8776;<wbr>&#126;<wbr>&#8729;<wbr>&#247;<wbr>&#8725;<wbr>&#8709;<wbr>&#61;<wbr>&#8801;<wbr>&#62;<wbr>&#8805;<wbr>&#8710;<wbr>&#8734;<wbr>&#8747;<wbr>&#60;<wbr>&#8804;<wbr>&#172;<wbr>&#8722;<wbr>&#215;<wbr>&#8800;<wbr>&#8706;<wbr>&#37;<wbr>&#8240;<wbr>&#43;<wbr>&#177;<wbr>&#8719;<wbr>&#8730;<wbr>&#8721;<wbr>&#8756;<wbr>&#181;<wbr>&#9829;<wbr>&#124;<wbr>&#166;<wbr>&#64;<wbr>&#38;<wbr>&#182;<wbr>&#169;<wbr>&#174;<wbr>&#167;<wbr>&#8482;<wbr>&#176;<wbr>&#8467;<wbr>&#94;<wbr>&#8224;<wbr>&#8225;<wbr>&#803;<wbr>&#180;<wbr>&#728;<wbr>&#711;<wbr>&#184;<wbr>&#710;<wbr>&#168;<wbr>&#729;<wbr>&#96;<wbr>&#733;<wbr>&#175;<wbr>&#731;<wbr>&#730;<wbr>&#732;<wbr>    </div>         
+&#65;<wbr>&#193;<wbr>&#258;<wbr>&#194;<wbr>&#196;<wbr>&#192;<wbr>&#256;<wbr>&#260;<wbr>&#197;<wbr>&#195;<wbr>&#198;<wbr>&#66;<wbr>&#67;<wbr>&#262;<wbr>&#268;<wbr>&#199;<wbr>&#68;<wbr>&#208;<wbr>&#270;<wbr>&#272;<wbr>&#69;<wbr>&#201;<wbr>&#282;<wbr>&#202;<wbr>&#203;<wbr>&#278;<wbr>&#200;<wbr>&#274;<wbr>&#280;<wbr>&#70;<wbr>&#71;<wbr>&#72;<wbr>&#73;<wbr>&#306;<wbr>&#205;<wbr>&#206;<wbr>&#207;<wbr>&#204;<wbr>&#298;<wbr>&#302;<wbr>&#74;<wbr>&#75;<wbr>&#76;<wbr>&#313;<wbr>&#317;<wbr>&#319;<wbr>&#77;<wbr>&#78;<wbr>&#323;<wbr>&#327;<wbr>&#209;<wbr>&#79;<wbr>&#211;<wbr>&#212;<wbr>&#214;<wbr>&#210;<wbr>&#336;<wbr>&#332;<wbr>&#216;<wbr>&#213;<wbr>&#338;<wbr>&#80;<wbr>&#222;<wbr>&#81;<wbr>&#82;<wbr>&#340;<wbr>&#344;<wbr>&#83;<wbr>&#346;<wbr>&#352;<wbr>&#350;<wbr>&#84;<wbr>&#358;<wbr>&#356;<wbr>&#354;<wbr>&#85;<wbr>&#218;<wbr>&#219;<wbr>&#220;<wbr>&#217;<wbr>&#368;<wbr>&#362;<wbr>&#370;<wbr>&#366;<wbr>&#86;<wbr>&#87;<wbr>&#7810;<wbr>&#372;<wbr>&#7812;<wbr>&#7808;<wbr>&#88;<wbr>&#89;<wbr>&#221;<wbr>&#374;<wbr>&#376;<wbr>&#7922;<wbr>&#90;<wbr>&#377;<wbr>&#381;<wbr>&#379;<wbr>&#97;<wbr>&#225;<wbr>&#259;<wbr>&#226;<wbr>&#228;<wbr>&#224;<wbr>&#257;<wbr>&#261;<wbr>&#229;<wbr>&#227;<wbr>&#230;<wbr>&#98;<wbr>&#99;<wbr>&#263;<wbr>&#269;<wbr>&#231;<wbr>&#100;<wbr>&#240;<wbr>&#271;<wbr>&#273;<wbr>&#101;<wbr>&#233;<wbr>&#283;<wbr>&#234;<wbr>&#235;<wbr>&#279;<wbr>&#232;<wbr>&#275;<wbr>&#281;<wbr>&#102;<wbr>&#103;<wbr>&#104;<wbr>&#105;<wbr>&#305;<wbr>&#237;<wbr>&#238;<wbr>&#239;<wbr>&#236;<wbr>&#307;<wbr>&#299;<wbr>&#303;<wbr>&#106;<wbr>&#567;<wbr>&#107;<wbr>&#108;<wbr>&#314;<wbr>&#318;<wbr>&#320;<wbr>&#109;<wbr>&#110;<wbr>&#324;<wbr>&#328;<wbr>&#241;<wbr>&#111;<wbr>&#243;<wbr>&#244;<wbr>&#246;<wbr>&#242;<wbr>&#337;<wbr>&#333;<wbr>&#248;<wbr>&#245;<wbr>&#339;<wbr>&#112;<wbr>&#254;<wbr>&#113;<wbr>&#114;<wbr>&#341;<wbr>&#345;<wbr>&#115;<wbr>&#347;<wbr>&#353;<wbr>&#351;<wbr>&#223;<wbr>&#116;<wbr>&#359;<wbr>&#357;<wbr>&#355;<wbr>&#117;<wbr>&#250;<wbr>&#251;<wbr>&#252;<wbr>&#249;<wbr>&#369;<wbr>&#363;<wbr>&#371;<wbr>&#367;<wbr>&#118;<wbr>&#119;<wbr>&#7811;<wbr>&#373;<wbr>&#7813;<wbr>&#7809;<wbr>&#120;<wbr>&#121;<wbr>&#253;<wbr>&#375;<wbr>&#255;<wbr>&#7923;<wbr>&#122;<wbr>&#378;<wbr>&#382;<wbr>&#380;<wbr>&#170;<wbr>&#186;<wbr>&#913;<wbr>&#914;<wbr>&#915;<wbr>&#916;<wbr>&#917;<wbr>&#918;<wbr>&#919;<wbr>&#920;<wbr>&#921;<wbr>&#922;<wbr>&#923;<wbr>&#924;<wbr>&#925;<wbr>&#926;<wbr>&#927;<wbr>&#928;<wbr>&#929;<wbr>&#931;<wbr>&#932;<wbr>&#933;<wbr>&#934;<wbr>&#935;<wbr>&#936;<wbr>&#937;<wbr>&#945;<wbr>&#946;<wbr>&#947;<wbr>&#948;<wbr>&#949;<wbr>&#950;<wbr>&#951;<wbr>&#952;<wbr>&#953;<wbr>&#954;<wbr>&#955;<wbr>&#956;<wbr>&#957;<wbr>&#958;<wbr>&#959;<wbr>&#960;<wbr>&#961;<wbr>&#963;<wbr>&#964;<wbr>&#965;<wbr>&#966;<wbr>&#967;<wbr>&#968;<wbr>&#969;<wbr>&#48;<wbr>&#49;<wbr>&#50;<wbr>&#51;<wbr>&#52;<wbr>&#53;<wbr>&#54;<wbr>&#55;<wbr>&#56;<wbr>&#57;<wbr>&#8543;<wbr>&#189;<wbr>&#8585;<wbr>&#8531;<wbr>&#8532;<wbr>&#188;<wbr>&#190;<wbr>&#8533;<wbr>&#8534;<wbr>&#8535;<wbr>&#8536;<wbr>&#8537;<wbr>&#8538;<wbr>&#8528;<wbr>&#8539;<wbr>&#8540;<wbr>&#8541;<wbr>&#8542;<wbr>&#8529;<wbr>&#8530;<wbr>&#42;<wbr>&#92;<wbr>&#183;<wbr>&#8226;<wbr>&#58;<wbr>&#44;<wbr>&#8230;<wbr>&#33;<wbr>&#8252;<wbr>&#161;<wbr>&#35;<wbr>&#8228;<wbr>&#46;<wbr>&#63;<wbr>&#191;<wbr>&#34;<wbr>&#39;<wbr>&#59;<wbr>&#47;<wbr>&#8229;<wbr>&#95;<wbr>&#123;<wbr>&#125;<wbr>&#91;<wbr>&#93;<wbr>&#40;<wbr>&#41;<wbr>&#45;<wbr>&#171;<wbr>&#187;<wbr>&#8249;<wbr>&#8250;<wbr>&#8222;<wbr>&#8220;<wbr>&#8221;<wbr>&#8216;<wbr>&#8219;<wbr>&#8217;<wbr>&#8218;<wbr>&#162;<wbr>&#164;<wbr>&#36;<wbr>&#8364;<wbr>&#402;<wbr>&#163;<wbr>&#165;<wbr>&#8776;<wbr>&#126;<wbr>&#8729;<wbr>&#247;<wbr>&#8725;<wbr>&#8709;<wbr>&#61;<wbr>&#8801;<wbr>&#62;<wbr>&#8805;<wbr>&#8710;<wbr>&#8734;<wbr>&#8747;<wbr>&#60;<wbr>&#8804;<wbr>&#172;<wbr>&#8722;<wbr>&#215;<wbr>&#8800;<wbr>&#8706;<wbr>&#37;<wbr>&#8240;<wbr>&#43;<wbr>&#177;<wbr>&#8719;<wbr>&#8730;<wbr>&#8721;<wbr>&#8756;<wbr>&#181;<wbr>&#9829;<wbr>&#124;<wbr>&#166;<wbr>&#64;<wbr>&#38;<wbr>&#182;<wbr>&#169;<wbr>&#174;<wbr>&#167;<wbr>&#8482;<wbr>&#176;<wbr>&#8467;<wbr>&#94;<wbr>&#8224;<wbr>&#8225;<wbr>&#803;<wbr>&#180;<wbr>&#728;<wbr>&#711;<wbr>&#184;<wbr>&#710;<wbr>&#168;<wbr>&#729;<wbr>&#96;<wbr>&#733;<wbr>&#175;<wbr>&#731;<wbr>&#730;<wbr>&#732;<wbr>    </div>
     </div>
 
 


### PR DESCRIPTION
Here I have changed a couple of "an"s on the website to "a"s -- they sound more natural to me this way, as a Canadian English-speaker, but maybe the original way is better in some other dialects.

I also added the text from the README of the monoOne branch, in place of the "lorem ipsum" text that was there before.

Finally, I didn't realize it before, but some trailing whitespace was removed by my editor when I saved the file.