### PR TITLE
Set all glyph widths to 575, so the fonts are recognized as monospaced

### DIFF
--- a/src/mononoki-Bold Italic.ufo/glyphs/C_cedilla.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/C_cedilla.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="Ccedilla" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <unicode hex="00C7"/>
   <outline>
     <component base="C"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/ampersand_ampersand.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/ampersand_ampersand.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="ampersand_ampersand" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="ampersand"/>
     <component base="ampersand"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/bar_bar.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/bar_bar.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="bar_bar" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="bar"/>
     <component base="bar"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/eight.dnom.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/eight.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="eight.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="232" y="207"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/eight.numr.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/eight.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="eight.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="eight.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold Italic.ufo/glyphs/equal_equal.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/equal_equal.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="equal_equal" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="equal"/>
     <component base="equal"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/equal_greater.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/equal_greater.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="equal_greater" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="equal"/>
     <component base="greater"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/exclam_equal.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/exclam_equal.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="exclam_equal" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="exclam"/>
     <component base="equal"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/five.dnom.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/five.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="five.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="101" y="216" type="line"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/five.numr.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/five.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="five.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="five.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold Italic.ufo/glyphs/four.dnom.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/four.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="four.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="208" y="121" type="line"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/four.numr.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/four.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="four.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="four.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold Italic.ufo/glyphs/fraction.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/fraction.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="fraction" format="1">
-  <advance width="75"/>
+  <advance width="575"/>
   <unicode hex="2044"/>
   <outline>
     <component base="uni2215" xOffset="-250" yOffset="15"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/greater_equal.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/greater_equal.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="greater_equal" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="greater"/>
     <component base="equal"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/greater_greater.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/greater_greater.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="greater_greater" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="greater"/>
     <component base="greater"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/hyphen_greater.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/hyphen_greater.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="hyphen_greater" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="hyphen"/>
     <component base="greater"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/less_less.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/less_less.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="less_less" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="less"/>
     <component base="less"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/lighthorzbxd.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/lighthorzbxd.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="lighthorzbxd" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
   </outline>
   <lib>

--- a/src/mononoki-Bold Italic.ufo/glyphs/nine.dnom.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/nine.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="nine.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="11" y="18" type="line" smooth="yes"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/nine.numr.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/nine.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="nine.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="nine.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold Italic.ufo/glyphs/one.dnom.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/one.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="one.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="161" y="49" type="line"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/one.numr.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/one.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="one.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="one.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold Italic.ufo/glyphs/seven.dnom.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/seven.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="seven.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="72" y="360" type="line"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/seven.numr.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/seven.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="seven.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="seven.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold Italic.ufo/glyphs/six.dnom.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/six.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="six.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="244" y="334" type="line"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/six.numr.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/six.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="six.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="six.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold Italic.ufo/glyphs/three.dnom.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/three.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="three.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="60" y="316" type="line" smooth="yes"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/three.numr.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/three.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="three.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="three.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold Italic.ufo/glyphs/two.dnom.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/two.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="two.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="68" y="49" type="line"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/two.numr.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/two.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="two.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="two.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold Italic.ufo/glyphs/uni0403.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/uni0403.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0403" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <unicode hex="0403"/>
   <outline>
     <component base="uni0413"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/uni0411.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/uni0411.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0411" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <unicode hex="0411"/>
   <outline>
     <contour>

--- a/src/mononoki-Bold Italic.ufo/glyphs/uni0413.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/uni0413.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0413" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <unicode hex="0413"/>
   <outline>
     <contour>

--- a/src/mononoki-Bold Italic.ufo/glyphs/uniE_0A_2.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/uniE_0A_2.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniE0A2" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <unicode hex="E0A2"/>
   <note>
     uniE0A2

--- a/src/mononoki-Bold Italic.ufo/glyphs/zero.dnom.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/zero.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="zero.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="83" y="365"/>

--- a/src/mononoki-Bold Italic.ufo/glyphs/zero.numr.glif
+++ b/src/mononoki-Bold Italic.ufo/glyphs/zero.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="zero.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="zero.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold.ufo/glyphs/ampersand_ampersand.glif
+++ b/src/mononoki-Bold.ufo/glyphs/ampersand_ampersand.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="ampersand_ampersand" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="ampersand"/>
     <component base="ampersand"/>

--- a/src/mononoki-Bold.ufo/glyphs/bar_bar.glif
+++ b/src/mononoki-Bold.ufo/glyphs/bar_bar.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="bar_bar" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="bar"/>
     <component base="bar"/>

--- a/src/mononoki-Bold.ufo/glyphs/eight.dnom.glif
+++ b/src/mononoki-Bold.ufo/glyphs/eight.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="eight.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="240" y="207"/>

--- a/src/mononoki-Bold.ufo/glyphs/eight.numr.glif
+++ b/src/mononoki-Bold.ufo/glyphs/eight.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="eight.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="eight.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold.ufo/glyphs/equal_equal.glif
+++ b/src/mononoki-Bold.ufo/glyphs/equal_equal.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="equal_equal" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="equal"/>
     <component base="equal"/>

--- a/src/mononoki-Bold.ufo/glyphs/equal_greater.glif
+++ b/src/mononoki-Bold.ufo/glyphs/equal_greater.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="equal_greater" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="equal"/>
     <component base="greater"/>

--- a/src/mononoki-Bold.ufo/glyphs/exclam_equal.glif
+++ b/src/mononoki-Bold.ufo/glyphs/exclam_equal.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="exclam_equal" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="exclam"/>
     <component base="equal"/>

--- a/src/mononoki-Bold.ufo/glyphs/five.dnom.glif
+++ b/src/mononoki-Bold.ufo/glyphs/five.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="five.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="107" y="216" type="line"/>

--- a/src/mononoki-Bold.ufo/glyphs/five.numr.glif
+++ b/src/mononoki-Bold.ufo/glyphs/five.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="five.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="five.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold.ufo/glyphs/four.dnom.glif
+++ b/src/mononoki-Bold.ufo/glyphs/four.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="four.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="228" y="121" type="line"/>

--- a/src/mononoki-Bold.ufo/glyphs/four.numr.glif
+++ b/src/mononoki-Bold.ufo/glyphs/four.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="four.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="four.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold.ufo/glyphs/fraction.glif
+++ b/src/mononoki-Bold.ufo/glyphs/fraction.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="fraction" format="1">
-  <advance width="75"/>
+  <advance width="575"/>
   <unicode hex="2044"/>
   <outline>
     <component base="uni2215" xOffset="-250" yOffset="15"/>

--- a/src/mononoki-Bold.ufo/glyphs/greater_equal.glif
+++ b/src/mononoki-Bold.ufo/glyphs/greater_equal.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="greater_equal" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="greater"/>
     <component base="equal"/>

--- a/src/mononoki-Bold.ufo/glyphs/greater_greater.glif
+++ b/src/mononoki-Bold.ufo/glyphs/greater_greater.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="greater_greater" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="greater"/>
     <component base="greater"/>

--- a/src/mononoki-Bold.ufo/glyphs/hyphen_greater.glif
+++ b/src/mononoki-Bold.ufo/glyphs/hyphen_greater.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="hyphen_greater" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="hyphen"/>
     <component base="greater"/>

--- a/src/mononoki-Bold.ufo/glyphs/less_less.glif
+++ b/src/mononoki-Bold.ufo/glyphs/less_less.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="less_less" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="less"/>
     <component base="less"/>

--- a/src/mononoki-Bold.ufo/glyphs/lighthorzbxd.glif
+++ b/src/mononoki-Bold.ufo/glyphs/lighthorzbxd.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="lighthorzbxd" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
   </outline>
   <lib>

--- a/src/mononoki-Bold.ufo/glyphs/nine.dnom.glif
+++ b/src/mononoki-Bold.ufo/glyphs/nine.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="nine.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="47" y="18" type="line" smooth="yes"/>

--- a/src/mononoki-Bold.ufo/glyphs/nine.numr.glif
+++ b/src/mononoki-Bold.ufo/glyphs/nine.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="nine.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="nine.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold.ufo/glyphs/one.dnom.glif
+++ b/src/mononoki-Bold.ufo/glyphs/one.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="one.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="193" y="49" type="line"/>

--- a/src/mononoki-Bold.ufo/glyphs/one.numr.glif
+++ b/src/mononoki-Bold.ufo/glyphs/one.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="one.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="one.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold.ufo/glyphs/seven.dnom.glif
+++ b/src/mononoki-Bold.ufo/glyphs/seven.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="seven.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="55" y="360" type="line"/>

--- a/src/mononoki-Bold.ufo/glyphs/seven.numr.glif
+++ b/src/mononoki-Bold.ufo/glyphs/seven.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="seven.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="seven.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold.ufo/glyphs/six.dnom.glif
+++ b/src/mononoki-Bold.ufo/glyphs/six.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="six.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="231" y="334" type="line"/>

--- a/src/mononoki-Bold.ufo/glyphs/six.numr.glif
+++ b/src/mononoki-Bold.ufo/glyphs/six.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="six.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="six.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold.ufo/glyphs/three.dnom.glif
+++ b/src/mononoki-Bold.ufo/glyphs/three.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="three.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="50" y="316" type="line"/>

--- a/src/mononoki-Bold.ufo/glyphs/three.numr.glif
+++ b/src/mononoki-Bold.ufo/glyphs/three.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="three.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="three.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold.ufo/glyphs/two.dnom.glif
+++ b/src/mononoki-Bold.ufo/glyphs/two.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="two.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="100" y="49" type="line"/>

--- a/src/mononoki-Bold.ufo/glyphs/two.numr.glif
+++ b/src/mononoki-Bold.ufo/glyphs/two.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="two.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="two.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Bold.ufo/glyphs/uniE_0A_2.glif
+++ b/src/mononoki-Bold.ufo/glyphs/uniE_0A_2.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniE0A2" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <unicode hex="E0A2"/>
   <note>
     uniE0A2

--- a/src/mononoki-Bold.ufo/glyphs/zero.dnom.glif
+++ b/src/mononoki-Bold.ufo/glyphs/zero.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="zero.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="65" y="365"/>

--- a/src/mononoki-Bold.ufo/glyphs/zero.numr.glif
+++ b/src/mononoki-Bold.ufo/glyphs/zero.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="zero.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="zero.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Italic.ufo/glyphs/ampersand_ampersand.glif
+++ b/src/mononoki-Italic.ufo/glyphs/ampersand_ampersand.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="ampersand_ampersand" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="ampersand"/>
     <component base="ampersand"/>

--- a/src/mononoki-Italic.ufo/glyphs/bar_bar.glif
+++ b/src/mononoki-Italic.ufo/glyphs/bar_bar.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="bar_bar" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="bar"/>
     <component base="bar"/>

--- a/src/mononoki-Italic.ufo/glyphs/eight.dnom.glif
+++ b/src/mononoki-Italic.ufo/glyphs/eight.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="eight.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="233" y="207"/>

--- a/src/mononoki-Italic.ufo/glyphs/eight.numr.glif
+++ b/src/mononoki-Italic.ufo/glyphs/eight.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="eight.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="eight.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Italic.ufo/glyphs/equal_equal.glif
+++ b/src/mononoki-Italic.ufo/glyphs/equal_equal.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="equal_equal" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="equal"/>
     <component base="equal"/>

--- a/src/mononoki-Italic.ufo/glyphs/equal_greater.glif
+++ b/src/mononoki-Italic.ufo/glyphs/equal_greater.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="equal_greater" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="equal"/>
     <component base="greater"/>

--- a/src/mononoki-Italic.ufo/glyphs/exclam_equal.glif
+++ b/src/mononoki-Italic.ufo/glyphs/exclam_equal.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="exclam_equal" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="exclam"/>
     <component base="equal"/>

--- a/src/mononoki-Italic.ufo/glyphs/five.dnom.glif
+++ b/src/mononoki-Italic.ufo/glyphs/five.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="five.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="101" y="216" type="line"/>

--- a/src/mononoki-Italic.ufo/glyphs/five.numr.glif
+++ b/src/mononoki-Italic.ufo/glyphs/five.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="five.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="five.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Italic.ufo/glyphs/four.dnom.glif
+++ b/src/mononoki-Italic.ufo/glyphs/four.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="four.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="208" y="121" type="line"/>

--- a/src/mononoki-Italic.ufo/glyphs/four.numr.glif
+++ b/src/mononoki-Italic.ufo/glyphs/four.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="four.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="four.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Italic.ufo/glyphs/fraction.glif
+++ b/src/mononoki-Italic.ufo/glyphs/fraction.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="fraction" format="1">
-  <advance width="75"/>
+  <advance width="575"/>
   <unicode hex="2044"/>
   <outline>
     <component base="uni2215" xOffset="-250" yOffset="15"/>

--- a/src/mononoki-Italic.ufo/glyphs/greater_equal.glif
+++ b/src/mononoki-Italic.ufo/glyphs/greater_equal.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="greater_equal" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="greater"/>
     <component base="equal"/>

--- a/src/mononoki-Italic.ufo/glyphs/greater_greater.glif
+++ b/src/mononoki-Italic.ufo/glyphs/greater_greater.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="greater_greater" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="greater"/>
     <component base="greater"/>

--- a/src/mononoki-Italic.ufo/glyphs/hyphen_greater.glif
+++ b/src/mononoki-Italic.ufo/glyphs/hyphen_greater.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="hyphen_greater" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="hyphen"/>
     <component base="greater"/>

--- a/src/mononoki-Italic.ufo/glyphs/less_less.glif
+++ b/src/mononoki-Italic.ufo/glyphs/less_less.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="less_less" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
     <component base="less"/>
     <component base="less"/>

--- a/src/mononoki-Italic.ufo/glyphs/lighthorzbxd.glif
+++ b/src/mononoki-Italic.ufo/glyphs/lighthorzbxd.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="lighthorzbxd" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
   </outline>
   <lib>

--- a/src/mononoki-Italic.ufo/glyphs/nine.dnom.glif
+++ b/src/mononoki-Italic.ufo/glyphs/nine.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="nine.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="11" y="18" type="line" smooth="yes"/>

--- a/src/mononoki-Italic.ufo/glyphs/nine.numr.glif
+++ b/src/mononoki-Italic.ufo/glyphs/nine.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="nine.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="nine.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Italic.ufo/glyphs/one.dnom.glif
+++ b/src/mononoki-Italic.ufo/glyphs/one.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="one.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="161" y="49" type="line"/>

--- a/src/mononoki-Italic.ufo/glyphs/one.numr.glif
+++ b/src/mononoki-Italic.ufo/glyphs/one.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="one.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="one.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Italic.ufo/glyphs/seven.dnom.glif
+++ b/src/mononoki-Italic.ufo/glyphs/seven.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="seven.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="72" y="360" type="line"/>

--- a/src/mononoki-Italic.ufo/glyphs/seven.numr.glif
+++ b/src/mononoki-Italic.ufo/glyphs/seven.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="seven.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="seven.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Italic.ufo/glyphs/six.dnom.glif
+++ b/src/mononoki-Italic.ufo/glyphs/six.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="six.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="244" y="334" type="line"/>

--- a/src/mononoki-Italic.ufo/glyphs/six.numr.glif
+++ b/src/mononoki-Italic.ufo/glyphs/six.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="six.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="six.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Italic.ufo/glyphs/three.dnom.glif
+++ b/src/mononoki-Italic.ufo/glyphs/three.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="three.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="60" y="316" type="line" smooth="yes"/>

--- a/src/mononoki-Italic.ufo/glyphs/three.numr.glif
+++ b/src/mononoki-Italic.ufo/glyphs/three.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="three.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="three.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Italic.ufo/glyphs/two.dnom.glif
+++ b/src/mononoki-Italic.ufo/glyphs/two.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="two.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="68" y="49" type="line"/>

--- a/src/mononoki-Italic.ufo/glyphs/two.numr.glif
+++ b/src/mononoki-Italic.ufo/glyphs/two.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="two.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="two.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Italic.ufo/glyphs/uniE_0A_2.glif
+++ b/src/mononoki-Italic.ufo/glyphs/uniE_0A_2.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniE0A2" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <unicode hex="E0A2"/>
   <note>
     uniE0A2

--- a/src/mononoki-Italic.ufo/glyphs/zero.dnom.glif
+++ b/src/mononoki-Italic.ufo/glyphs/zero.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="zero.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="83" y="365"/>

--- a/src/mononoki-Italic.ufo/glyphs/zero.numr.glif
+++ b/src/mononoki-Italic.ufo/glyphs/zero.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="zero.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="zero.dnom" xOffset="63" yOffset="400"/>
   </outline>

--- a/src/mononoki-Regular.ufo/glyphs/eight.dnom.glif
+++ b/src/mononoki-Regular.ufo/glyphs/eight.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="eight.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="240" y="207"/>

--- a/src/mononoki-Regular.ufo/glyphs/eight.numr.glif
+++ b/src/mononoki-Regular.ufo/glyphs/eight.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="eight.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="eight.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Regular.ufo/glyphs/five.dnom.glif
+++ b/src/mononoki-Regular.ufo/glyphs/five.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="five.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="107" y="216" type="line"/>

--- a/src/mononoki-Regular.ufo/glyphs/five.numr.glif
+++ b/src/mononoki-Regular.ufo/glyphs/five.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="five.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="five.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Regular.ufo/glyphs/fiveeighths.glif
+++ b/src/mononoki-Regular.ufo/glyphs/fiveeighths.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="fiveeighths" format="1">
-  <advance width="588"/>
+  <advance width="575"/>
   <unicode hex="215D"/>
   <outline>
     <component base="five.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/four.dnom.glif
+++ b/src/mononoki-Regular.ufo/glyphs/four.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="four.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="228" y="121" type="line"/>

--- a/src/mononoki-Regular.ufo/glyphs/four.numr.glif
+++ b/src/mononoki-Regular.ufo/glyphs/four.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="four.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="four.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Regular.ufo/glyphs/fraction.glif
+++ b/src/mononoki-Regular.ufo/glyphs/fraction.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="fraction" format="1">
-  <advance width="75"/>
+  <advance width="575"/>
   <unicode hex="2044"/>
   <outline>
     <component base="uni2215" xOffset="-250" yOffset="15"/>

--- a/src/mononoki-Regular.ufo/glyphs/lighthorzbxd.glif
+++ b/src/mononoki-Regular.ufo/glyphs/lighthorzbxd.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="lighthorzbxd" format="1">
-  <advance width="600"/>
+  <advance width="575"/>
   <outline>
   </outline>
   <lib>

--- a/src/mononoki-Regular.ufo/glyphs/nine.dnom.glif
+++ b/src/mononoki-Regular.ufo/glyphs/nine.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="nine.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="47" y="18" type="line" smooth="yes"/>

--- a/src/mononoki-Regular.ufo/glyphs/nine.numr.glif
+++ b/src/mononoki-Regular.ufo/glyphs/nine.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="nine.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="nine.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Regular.ufo/glyphs/one.dnom.glif
+++ b/src/mononoki-Regular.ufo/glyphs/one.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="one.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="193" y="49" type="line"/>

--- a/src/mononoki-Regular.ufo/glyphs/one.numr.glif
+++ b/src/mononoki-Regular.ufo/glyphs/one.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="one.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="one.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Regular.ufo/glyphs/oneeighth.glif
+++ b/src/mononoki-Regular.ufo/glyphs/oneeighth.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="oneeighth" format="1">
-  <advance width="590"/>
+  <advance width="575"/>
   <unicode hex="215B"/>
   <outline>
     <component base="one.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/onehalf.glif
+++ b/src/mononoki-Regular.ufo/glyphs/onehalf.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="onehalf" format="1">
-  <advance width="587"/>
+  <advance width="575"/>
   <unicode hex="00BD"/>
   <outline>
     <component base="one.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/onequarter.glif
+++ b/src/mononoki-Regular.ufo/glyphs/onequarter.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="onequarter" format="1">
-  <advance width="585"/>
+  <advance width="575"/>
   <unicode hex="00BC"/>
   <outline>
     <component base="one.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/seven.dnom.glif
+++ b/src/mononoki-Regular.ufo/glyphs/seven.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="seven.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="55" y="360" type="line"/>

--- a/src/mononoki-Regular.ufo/glyphs/seven.numr.glif
+++ b/src/mononoki-Regular.ufo/glyphs/seven.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="seven.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="seven.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Regular.ufo/glyphs/seveneighths.glif
+++ b/src/mononoki-Regular.ufo/glyphs/seveneighths.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="seveneighths" format="1">
-  <advance width="577"/>
+  <advance width="575"/>
   <unicode hex="215E"/>
   <outline>
     <component base="seven.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/six.dnom.glif
+++ b/src/mononoki-Regular.ufo/glyphs/six.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="six.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="231" y="334" type="line"/>

--- a/src/mononoki-Regular.ufo/glyphs/six.numr.glif
+++ b/src/mononoki-Regular.ufo/glyphs/six.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="six.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="six.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Regular.ufo/glyphs/three.dnom.glif
+++ b/src/mononoki-Regular.ufo/glyphs/three.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="three.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="50" y="316" type="line" smooth="yes"/>

--- a/src/mononoki-Regular.ufo/glyphs/three.numr.glif
+++ b/src/mononoki-Regular.ufo/glyphs/three.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="three.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="three.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Regular.ufo/glyphs/threeeighths.glif
+++ b/src/mononoki-Regular.ufo/glyphs/threeeighths.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="threeeighths" format="1">
-  <advance width="590"/>
+  <advance width="575"/>
   <unicode hex="215C"/>
   <outline>
     <component base="three.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/threequarters.glif
+++ b/src/mononoki-Regular.ufo/glyphs/threequarters.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="threequarters" format="1">
-  <advance width="585"/>
+  <advance width="575"/>
   <unicode hex="00BE"/>
   <outline>
     <component base="three.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/two.dnom.glif
+++ b/src/mononoki-Regular.ufo/glyphs/two.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="two.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="100" y="49" type="line"/>

--- a/src/mononoki-Regular.ufo/glyphs/two.numr.glif
+++ b/src/mononoki-Regular.ufo/glyphs/two.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="two.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="two.dnom" yOffset="400"/>
   </outline>

--- a/src/mononoki-Regular.ufo/glyphs/uni044C_.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni044C_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni044C" format="1">
-  <advance width="585"/>
+  <advance width="575"/>
   <unicode hex="044C"/>
   <outline>
     <contour>

--- a/src/mononoki-Regular.ufo/glyphs/uni2150.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni2150.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2150" format="1">
-  <advance width="588"/>
+  <advance width="575"/>
   <unicode hex="2150"/>
   <outline>
     <component base="one.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/uni2151.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni2151.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2151" format="1">
-  <advance width="580"/>
+  <advance width="575"/>
   <unicode hex="2151"/>
   <outline>
     <component base="one.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/uni2152.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni2152.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152" format="1">
-  <advance width="565"/>
+  <advance width="575"/>
   <unicode hex="2152"/>
   <outline>
     <contour>

--- a/src/mononoki-Regular.ufo/glyphs/uni2154.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni2154.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2154" format="1">
-  <advance width="563"/>
+  <advance width="575"/>
   <unicode hex="2154"/>
   <outline>
     <component base="two.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/uni2155.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni2155.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2155" format="1">
-  <advance width="577"/>
+  <advance width="575"/>
   <unicode hex="2155"/>
   <outline>
     <component base="one.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/uni2156.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni2156.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2156" format="1">
-  <advance width="565"/>
+  <advance width="575"/>
   <unicode hex="2156"/>
   <outline>
     <component base="two.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/uni2157.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni2157.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2157" format="1">
-  <advance width="577"/>
+  <advance width="575"/>
   <unicode hex="2157"/>
   <outline>
     <component base="three.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/uni2158.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni2158.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2158" format="1">
-  <advance width="567"/>
+  <advance width="575"/>
   <unicode hex="2158"/>
   <outline>
     <component base="four.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/uni2159.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni2159.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2159" format="1">
-  <advance width="579"/>
+  <advance width="575"/>
   <unicode hex="2159"/>
   <outline>
     <component base="one.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/uni215A_.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni215A_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni215A" format="1">
-  <advance width="577"/>
+  <advance width="575"/>
   <unicode hex="215A"/>
   <outline>
     <component base="five.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/uni215F_.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni215F_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni215F" format="1">
-  <advance width="493"/>
+  <advance width="575"/>
   <unicode hex="215F"/>
   <outline>
     <contour>

--- a/src/mononoki-Regular.ufo/glyphs/uni2189.glif
+++ b/src/mononoki-Regular.ufo/glyphs/uni2189.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2189" format="1">
-  <advance width="560"/>
+  <advance width="575"/>
   <unicode hex="2189"/>
   <outline>
     <component base="zero.numr"/>

--- a/src/mononoki-Regular.ufo/glyphs/zero.dnom.glif
+++ b/src/mononoki-Regular.ufo/glyphs/zero.dnom.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="zero.dnom" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <contour>
       <point x="65" y="365"/>

--- a/src/mononoki-Regular.ufo/glyphs/zero.numr.glif
+++ b/src/mononoki-Regular.ufo/glyphs/zero.numr.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="zero.numr" format="1">
-  <advance width="250"/>
+  <advance width="575"/>
   <outline>
     <component base="zero.dnom" yOffset="400"/>
   </outline>


### PR DESCRIPTION
Keep glyph widths of 1150, which is exactly twice the base width of 575.